### PR TITLE
[PB-1998]: Integrate 8x8 backend

### DIFF
--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -23,11 +23,12 @@ import {
 import { JITSI_CONNECTION_URL_KEY } from './constants';
 import logger from './logger';
 import { ConnectionFailedError, IIceServers } from './types';
+import { get8x8AppId, get8x8JWT, get8x8Options } from './options8x8';
 
 /**
  * The options that will be passed to the JitsiConnection instance.
  */
-interface IOptions extends IConfigState {
+export interface IOptions extends IConfigState {
     iceServersOverride?: IIceServers;
     preferVisitor?: boolean;
 }
@@ -220,9 +221,13 @@ export function _connectInternal(id?: string, password?: string) {
         const state = getState();
         const options = constructOptions(state);
         const { locationURL } = state['features/base/connection'];
-        const { jwt } = state['features/base/jwt'];
 
-        const connection = new JitsiMeetJS.JitsiConnection(options.appId, jwt, options);
+        const room = state['features/base/conference'].room || '';
+        const jwt = get8x8JWT();
+        const appId = get8x8AppId();
+        const newOptions = get8x8Options(options, appId, room);
+
+        const connection = new JitsiMeetJS.JitsiConnection(options.appId, jwt, newOptions);
 
         connection[JITSI_CONNECTION_URL_KEY] = locationURL;
 

--- a/react/features/base/connection/options8x8.ts
+++ b/react/features/base/connection/options8x8.ts
@@ -1,0 +1,27 @@
+import { IOptions } from "./actions.any";
+
+export function get8x8JWT() {
+    //A Jitsi JWT, can be manually generated here: https://jaas.8x8.vc/#/apikeys
+    //more documentation: https://developer.8x8.com/jaas/docs/api-keys-jwt
+    const jwt = '';
+    return jwt;
+}
+
+export function get8x8AppId() {
+    //AppID is an unique user ID, can be aquired from https://jaas.8x8.vc/#/apikeys
+    const appId = '';
+    return appId;
+}
+
+export function get8x8Options(options: IOptions, appId: string, room: string) {
+    const newOptions = Object.assign(options, {
+        hosts: {
+            domain: '8x8.vc',
+            muc: `conference.${appId}.8x8.vc`,
+            focus: 'focus.8x8.vc'
+        },
+        serviceUrl: `wss://8x8.vc/${appId}/xmpp-websocket?room=${room}`,
+        websocketKeepAliveUrl: `https://8x8.vc/${appId}/_unlock?room=${room}`,
+    });
+    return newOptions;
+}


### PR DESCRIPTION
Adds 8x8 integration with the backend

- It is needed an AppID -> https://jaas.8x8.vc/#/apikeys
- It is needed a Jitsi JWT -> https://jaas.8x8.vc/#/apikeys